### PR TITLE
Fix issue where empty rows appear for learner category selector

### DIFF
--- a/R/codefile.R
+++ b/R/codefile.R
@@ -30,7 +30,7 @@ thresholds<-read.csv("Data/thresholds.csv",
 # relevelling factor levels of learner category
 obsm$Provider<-paste(obsm$UKPRN,"-",obsm$`Provider Name`)
 obsm<-obsm %>% select(c(16,3:15))
-obsm$`Learner Category`<-factor(obsm$`Learner Category`,levels=levs[,1])
+obsm %>% arrange(factor(`Learner Category`,levels=levs[,1]))
 summ$Provider<-paste(summ$UKPRN,"-",summ$`Provider Name`)
 summ<-summ %>% select(c(17,3:16)) %>% filter(`Learner type`=="All learners")
 


### PR DESCRIPTION
The issue seems to have been due to the way the OBSM data frame was ordered so have used another method to arrange rows